### PR TITLE
Migrate AssertJ to a test compile dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,10 +94,10 @@ project(':kollection') {
         compile(
                 project(':collection'),
                 "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
-                "org.assertj:assertj-core:$assertJVersion",
         )
         testCompile(
                 "junit:junit:$junitVersion",
+                "org.assertj:assertj-core:$assertJVersion",
         )
     }
 }


### PR DESCRIPTION
Hello! Thanks for the cool library. Been playing with it on the side and it's working really nicely :)

This is a simple change.

I've moved AssertJ into the list of testCompile dependencies. This should reduce the method count (a win for Android development) and reduce version conflicts for folks consuming this library.

Let me know if this works from your end!
