### PR TITLE
Remove all instanceof to test for black/red trees

### DIFF
--- a/collection/src/main/java/com/github/andrewoma/dexx/collection/internal/redblack/AbstractDefaultTree.java
+++ b/collection/src/main/java/com/github/andrewoma/dexx/collection/internal/redblack/AbstractDefaultTree.java
@@ -43,6 +43,16 @@ final class DefaultRedTree<K, V> extends AbstractDefaultTree<K, V> implements Re
         super(key, value, left, right);
     }
 
+    @Override
+    public boolean isBlack() {
+        return false;
+    }
+
+    @Override
+    public boolean isRed() {
+        return true;
+    }
+
     public Tree<K, V> black() {
         return new DefaultBlackTree<K, V>(getKey(null), getValue(), getLeft(), getRight());
     }
@@ -60,6 +70,16 @@ final class DefaultRedTree<K, V> extends AbstractDefaultTree<K, V> implements Re
 final class DefaultBlackTree<K, V> extends AbstractDefaultTree<K, V> implements BlackTree<K, V> {
     public DefaultBlackTree(K key, V value, Tree<K, V> left, Tree<K, V> right) {
         super(key, value, left, right);
+    }
+
+    @Override
+    public boolean isBlack() {
+        return true;
+    }
+
+    @Override
+    public boolean isRed() {
+        return false;
     }
 
     public Tree<K, V> black() {

--- a/collection/src/main/java/com/github/andrewoma/dexx/collection/internal/redblack/AbstractDerivedKeyTree.java
+++ b/collection/src/main/java/com/github/andrewoma/dexx/collection/internal/redblack/AbstractDerivedKeyTree.java
@@ -45,6 +45,16 @@ class DerivedKeyRedTree<K, V> extends AbstractDerivedKeyTree<K, V> implements Re
         super(left, right, value);
     }
 
+    @Override
+    public boolean isBlack() {
+        return false;
+    }
+
+    @Override
+    public boolean isRed() {
+        return true;
+    }
+
     public Tree<K, V> black() {
         return new DerivedKeyBlackTree<K, V>(getLeft(), getRight(), getValue());
     }
@@ -58,6 +68,16 @@ class DerivedKeyBlackTree<K, V> extends AbstractDerivedKeyTree<K, V> implements 
 
     DerivedKeyBlackTree(Tree<K, V> left, Tree<K, V> right, V value) {
         super(left, right, value);
+    }
+
+    @Override
+    public boolean isBlack() {
+        return true;
+    }
+
+    @Override
+    public boolean isRed() {
+        return false;
     }
 
     public Tree<K, V> black() {

--- a/collection/src/main/java/com/github/andrewoma/dexx/collection/internal/redblack/RedBlackTree.java
+++ b/collection/src/main/java/com/github/andrewoma/dexx/collection/internal/redblack/RedBlackTree.java
@@ -192,11 +192,11 @@ public class RedBlackTree<K, V> {
     }
 
     private boolean isRedTree(Tree<?, ?> tree) {
-        return tree instanceof RedTree;
+        return tree != null && tree.isRed();
     }
 
     private boolean isBlackTree(Tree<?, ?> tree) {
-        return tree instanceof BlackTree;
+        return tree != null && tree.isBlack();
     }
 
     private Tree<K, V> blacken(Tree<K, V> t) {
@@ -296,7 +296,7 @@ public class RedBlackTree<K, V> {
     }
 
     private Tree<K, V> subl(Tree<K, V> t) {
-        if (t instanceof BlackTree)
+        if (isBlackTree(t))
             return t.red();
 
         throw new RuntimeException("Defect: invariance violation; expected black, got " + t);

--- a/collection/src/main/java/com/github/andrewoma/dexx/collection/internal/redblack/Tree.java
+++ b/collection/src/main/java/com/github/andrewoma/dexx/collection/internal/redblack/Tree.java
@@ -30,6 +30,10 @@ import com.github.andrewoma.dexx.collection.KeyFunction;
 public interface Tree<K, V> {
     int count();
 
+    boolean isBlack();
+
+    boolean isRed();
+
     Tree<K, V> black();
 
     Tree<K, V> red();


### PR DESCRIPTION
There was a performance bottleneck with all the `instanceof` tests done to recursively test for black or red sub-trees. Adding 100 elements is now almost 3 times faster.

```
Benchmark                      (implementation)  (size)  Mode  Cnt      Score      Error   Units
Sets.append                        Dexx TreeSet     100  avgt   20  24352.449  ± 654.566   ns/op
Sets.append               Modified Dexx TreeSet     100  avgt   20   7647.562  ± 282.896   ns/op
```
